### PR TITLE
[ISSUE-2] Change out deprecated protocol for SQLAlchemy

### DIFF
--- a/app/alembic.ini
+++ b/app/alembic.ini
@@ -35,7 +35,7 @@ script_location = ./data/migrations
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = postgres://root:toor@database/main
+sqlalchemy.url = postgresql://root:toor@database/main
 
 
 [post_write_hooks]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         ports:
             - "8000:8000"
         environment:
-            DATABASE_URL: "postgres://database:5432"
+            DATABASE_URL: "postgresql://database:5432"
             PGDATABASE: "main"
             PGUSER: "root"
             PGPASSWORD: "toor"


### PR DESCRIPTION
### Description

Upping the API container was failing failing on the following error:

```
Can't load plugin: sqlalchemy.dialects:postgres
```

This is due to the deprecation of the `postgres` protocol for `postgresql` in version 1.4. See https://stackoverflow.com/a/66794960.

### Issue

https://github.com/ab7/api-boilerplate/issues/2

### Testing

* Build the branch locally.
* Check the API logs for success:

    ```
    api_1       | INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
    api_1       | INFO:     Started reloader process [8] using statreload
    api_1       | INFO:     Started server process [11]
    api_1       | INFO:     Waiting for application startup.
    api_1       | INFO:     Application startup complete.
    ```

* Navigate to http://localhost:8000 and verify "Hello, World!" response is returned:

    ```
    {"message":"Hello, World!"}
    ```
